### PR TITLE
Minor fixes in startup script

### DIFF
--- a/AzureCloudServiceSample/WebRoleSample/Startup/SSLConfigure.cmd
+++ b/AzureCloudServiceSample/WebRoleSample/Startup/SSLConfigure.cmd
@@ -12,9 +12,8 @@ IF "%ComputeEmulatorRunning%" == "false" (
 IF %EXECUTE_PS1% EQU 1 (
 	echo "Invoking SSLConfigure.ps1 on Azure service at %TIME% on %DATE%" >> %LOG_FILE% 2>&1	
 	PowerShell -ExecutionPolicy Unrestricted %~dp0SSLConfigure.ps1 -sco  >> %LOG_FILE% 2>&1
-	IF %ERRORLEVEL% NEQ 0 (EXIT /B %ERRORLEVEL%)
 ) ELSE (
 	echo "Skipping SSLConfigure.ps1 invocation on emulated environment" >> %LOG_FILE% 2>&1	
 )    
 
-EXIT /B 0 
+EXIT /B %ERRORLEVEL%

--- a/AzureCloudServiceSample/WebRoleSample/Startup/SSLConfigure.ps1
+++ b/AzureCloudServiceSample/WebRoleSample/Startup/SSLConfigure.ps1
@@ -210,7 +210,7 @@ If ($reboot) {
   $rand = [System.Random]::new($tick)
   $sec = $rand.Next(30, 600)
   Write-Host "Rebooting after", $sec, " second(s)..."
-  Write-Host  shutdown.exe /r /t $sec /c "Crypto settings changed" /f /d p:2:4
+  shutdown.exe /r /t $sec /c "Crypto settings changed" /f /d p:2:4
 } Else {
   Write-Host "Nothing get updated."
 }


### PR DESCRIPTION
We were looking to integrate this code, and identified some fixes to the startup script we wanted to merge back upstream.

1) In batch %ERRORLEVEL% is mutated on every read, so we replace the exit with EXIT /B %ERRORLEVEL% to return 0 or 1 based on powershell error

2) Shutdown was not getting called because of Write-Host. Removed the Write-host block so that shutdowns can occur as expected.